### PR TITLE
docs: fix installed apps casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add `django-view-manager.utils` to the INSTALLED_APPS in settings. If possible, 
 ```python
 INSTALLED_APPS = [
     ...
-    "django-view-manager.utils",
+    "django_view_manager.utils",
     ...
 ]
 ```


### PR DESCRIPTION
Using the example as it was gives this error when loading the settings: `ModuleNotFoundError: No module named 'django-view-manager'`