### PR TITLE
feat(utils): set explicit app label to avoid conflicts

### DIFF
--- a/django_view_manager/utils/apps.py
+++ b/django_view_manager/utils/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class UtilsConfig(AppConfig):
     name = "django_view_manager.utils"
     verbose_name = "Utils"
+    label = "django_view_manager_utils"


### PR DESCRIPTION
Django requires unique app labels, and "utils" is a common name that can cause project conflicts. Setting an explicit label increases the likelihood of compatibility without affecting functionality.