### PR TITLE
chore: ignore .egg-info when lib is installed editablely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Django
 django_view_manager_db
+
+# Python
+*.egg-info


### PR DESCRIPTION
This makes it so that generated files are not ready to be added into git when the library is cloned locally and installed using pip install -e:
```
$ git remote -v
origin  git@github.com:arrai-innovations/django-view-manager.git (fetch)
origin  git@github.com:arrai-innovations/django-view-manager.git (push)
$ git status
On branch app-label-deduping
Your branch is up to date with 'origin/app-label-deduping'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        django_view_manager.egg-info/

nothing added to commit but untracked files present (use "git add" to track)
```