### PR TITLE
chore: fix names to not include spaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ workflows:
     test_and_build:
         jobs:
             - tests:
-                name: python 3.9 - django 4.2
+                name: python_3.9-django_4.2
                 context: arrai-global
                 executor: python39
                 django: django_4.2
@@ -161,7 +161,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.10 - django 4.2
+                name: python_3.10-django_4.2
                 context: arrai-global
                 executor: python310
                 django: django_4.2
@@ -171,7 +171,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.10 - django 5.1
+                name: python_3.10-django_5.1
                 context: arrai-global
                 executor: python310
                 django: django_5.1
@@ -181,7 +181,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.10 - django 5.2
+                name: python_3.10-django_5.2
                 context: arrai-global
                 executor: python310
                 django: django_5.2
@@ -191,7 +191,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.11 - django 4.2
+                name: python_3.11-django_4.2
                 context: arrai-global
                 executor: python311
                 django: django_4.2
@@ -201,7 +201,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.11 - django 5.1
+                name: python_3.11-django_5.1
                 context: arrai-global
                 executor: python311
                 django: django_5.1
@@ -211,7 +211,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.11 - django 5.2
+                name: python_3.11-django_5.2
                 context: arrai-global
                 executor: python311
                 django: django_5.2
@@ -221,7 +221,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.12 - django 4.2
+                name: python_3.12-django_4.2
                 context: arrai-global
                 executor: python312
                 django: django_4.2
@@ -231,7 +231,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.12 - django 5.1
+                name: python_3.12-django_5.1
                 context: arrai-global
                 executor: python312
                 django: django_5.1
@@ -241,7 +241,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.12 - django 5.2
+                name: python_3.12-django_5.2
                 context: arrai-global
                 executor: python312
                 django: django_5.2
@@ -251,7 +251,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.13 - django 5.1
+                name: python_3.13-django_5.1
                 context: arrai-global
                 executor: python313
                 django: django_5.1
@@ -261,7 +261,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.13 - django 5.2
+                name: python_3.13-django_5.2
                 context: arrai-global
                 executor: python313
                 django: django_5.2
@@ -271,7 +271,7 @@ workflows:
                     tags:
                         only: /.*/
             - tests:
-                name: python 3.14 - django 5.2
+                name: python_3.14-django_5.2
                 context: arrai-global
                 executor: python314
                 django: django_5.2
@@ -283,19 +283,19 @@ workflows:
             - build:
                 name: build
                 requires:
-                    - python 3.9 - django 4.2
-                    - python 3.10 - django 4.2
-                    - python 3.10 - django 5.1
-                    - python 3.10 - django 5.2
-                    - python 3.11 - django 4.2
-                    - python 3.11 - django 5.1
-                    - python 3.11 - django 5.2
-                    - python 3.12 - django 4.2
-                    - python 3.12 - django 5.1
-                    - python 3.12 - django 5.2
-                    - python 3.13 - django 5.1
-                    - python 3.13 - django 5.2
-                    - python 3.14 - django 5.2
+                    - python_3.9-django_4.2
+                    - python_3.10-django_4.2
+                    - python_3.10-django_5.1
+                    - python_3.10-django_5.2
+                    - python_3.11-django_4.2
+                    - python_3.11-django_5.1
+                    - python_3.11-django_5.2
+                    - python_3.12-django_4.2
+                    - python_3.12-django_5.1
+                    - python_3.12-django_5.2
+                    - python_3.13-django_5.1
+                    - python_3.13-django_5.2
+                    - python_3.14-django_5.2
                 filters:
                     branches:
                         only: /.*/

--- a/README.md
+++ b/README.md
@@ -10,31 +10,31 @@ Refer to folder and file structure, and usage, for more detailed information.
 
 ![Flake8](https://docs.arrai.dev/django-view-manager/artifacts/main/flake8.svg)
 
-![Python 3.9 - Django 4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.9%20-%20django%204.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.9%20-%20django%204.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.9%20-%20django%204.2/)
+![Python_3.9-Django_4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.9-django_4.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.9-django_4.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.9-django_4.2/)
 
-![Python 3.10 - Django 4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.10%20-%20django%204.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.10%20-%20django%204.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.10%20-%20django%204.2/)
+![Python_3.10-Django_4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.10-django_4.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.10-django_4.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.10-django_4.2/)
 
-![Python 3.10 - Django 5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.10%20-%20django%205.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.10%20-%20django%205.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.10%20-%20django%205.1/)
+![Python_3.10-Django_5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.10-django_5.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.10-django_5.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.10-django_5.1/)
 
-![Python 3.10 - Django 5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.10%20-%20django%205.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.10%20-%20django%205.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.10%20-%20django%205.2/)
+![Python_3.10-Django_5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.10-django_5.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.10-django_5.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.10-django_5.2/)
 
-![Python 3.11 - Django 4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.11%20-%20django%204.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.11%20-%20django%204.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.11%20-%20django%204.2/)
+![Python_3.11-Django_4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.11-django_4.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.11-django_4.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.11-django_4.2/)
 
-![Python 3.11 - Django 5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.11%20-%20django%205.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.11%20-%20django%205.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.11%20-%20django%205.1/)
+![Python_3.11-Django_5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.11-django_5.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.11-django_5.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.11-django_5.1/)
 
-![Python 3.11 - Django 5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.11%20-%20django%205.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.11%20-%20django%205.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.11%20-%20django%205.2/)
+![Python_3.11-Django_5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.11-django_5.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.11-django_5.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.11-django_5.2/)
 
-![Python 3.12 - Django 4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.12%20-%20django%204.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.12%20-%20django%204.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.12%20-%20django%204.2/)
+![Python_3.12-Django_4.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.12-django_4.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.12-django_4.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.12-django_4.2/)
 
-![Python 3.12 - Django 5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.12%20-%20django%205.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.12%20-%20django%205.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.12%20-%20django%205.1/)
+![Python_3.12-Django_5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.12-django_5.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.12-django_5.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.12-django_5.1/)
 
-![Python 3.12 - Django 5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.12%20-%20django%205.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.12%20-%20django%205.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.12%20-%20django%205.2/)
+![Python_3.12-Django_5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.12-django_5.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.12-django_5.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.12-django_5.2/)
 
-![Python 3.13 - Django 5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.13%20-%20django%205.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.13%20-%20django%205.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.13%20-%20django%205.1/)
+![Python_3.13-Django_5.1](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.13-django_5.1.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.13-django_5.1.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.13-django_5.1/)
 
-![Python 3.13 - Django 5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.13%20-%20django%205.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.13%20-%20django%205.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.13%20-%20django%205.2/)
+![Python_3.13-Django_5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.13-django_5.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.13-django_5.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.13-django_5.2/)
 
-![Python 3.14 - Django 5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.14%20-%20django%205.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python%203.14%20-%20django%205.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python%203.14%20-%20django%205.2/)
+![Python_3.14-Django_5.2](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.14-django_5.2.svg) [![Coverage](https://docs.arrai.dev/django-view-manager/artifacts/main/python_3.14-django_5.2.coverage.svg)](https://docs.arrai.dev/django-view-manager/artifacts/main/htmlcov_python_3.14-django_5.2/)
 
 **Table of Contents**
 


### PR DESCRIPTION
Removed the spaces in the job names and urls, since they weren't working.