### PR TITLE
test: tolerate argparse choice formatting in invalid table test

### DIFF
--- a/tests/employees/tests.py
+++ b/tests/employees/tests.py
@@ -23,20 +23,20 @@ class EmployeesTestCase(ManagementCommandTestCase):
 
     def test_bad_db_table_name(self):
         _out, err = self.call_command(["manage.py", "makeviewmigration", "employees_employeehates", "create_view"])
-        if self.python_version >= (3, 12):
-            self.assertIn(
-                "manage.py makeviewmigration: error: argument db_table_name: invalid choice: 'employees_"
-                "employeehates' (choose from animals_pets, band_info, employees_employeelikes, food_sweets, "
-                "store_productcalculations, store_purchasedproductcalculations)",
-                err,
-            )
-        else:  # python 3.9, 3.10, 3.11
-            self.assertIn(
-                "manage.py makeviewmigration: error: argument db_table_name: invalid choice: 'employees_"
-                "employeehates' (choose from 'animals_pets', 'band_info', 'employees_employeelikes', 'food_sweets', "
-                "'store_productcalculations', 'store_purchasedproductcalculations')",
-                err,
-            )
+        err_text = " ".join(err)
+        self.assertIn(
+            "manage.py makeviewmigration: error: argument db_table_name: invalid choice: 'employees_employeehates'",
+            err_text,
+        )
+        for choice in (
+            "animals_pets",
+            "band_info",
+            "employees_employeelikes",
+            "food_sweets",
+            "store_productcalculations",
+            "store_purchasedproductcalculations",
+        ):
+            self.assertIn(choice, err_text)
 
     def test_no_sql_folder(self):
         out, err = self.call_command(["manage.py", "makeviewmigration", "employees_employeelikes", "create_view"])


### PR DESCRIPTION
<!--
Title: test: tolerate argparse choice formatting in invalid table test

Suggested commit message:
test: tolerate argparse choice formatting in invalid table test
-->

The bad table name test assumed one exact `argparse` rendering for `choices`. Python 3.12.3 with Django 5.2.17 quotes those choices. That formatting made `test_bad_db_table_name` fail even though `makeviewmigration` still rejected the invalid table name and listed the valid unmanaged view tables.

This branch checks the command contract instead: the error names `employees_employeehates`, and the allowed choices include each unmanaged view table. The test still covers the invalid input path across the existing Python and Django matrix without pinning to one standard library message format.

## Verification

- `.venv/bin/python manage.py test`
- Local environment: Python 3.12.3, Django 5.2.17.
- CircleCI will verify the configured Python 3.9 to 3.14 and Django 4.2 to 5.2 combinations after the branch reaches CI.
